### PR TITLE
Ugly fix for optional spaces around username

### DIFF
--- a/filter-sudo.conf
+++ b/filter-sudo.conf
@@ -1,14 +1,14 @@
 filter {
     if "COMMAND" in [message] {
       grok {
-        match => ["message","%{DATA:[user][name]} :( %{DATA:[sudo][error]} ;)? TTY=%{DATA:[sudo][terminal][device]} ; PWD=%{DATA:[sudo][pwd]} ; USER=%{DATA:[sudo][user]} ; COMMAND=%{GREEDYDATA:[sudo][command]}"]
+        match => ["message","%{SPACE}%{DATA:[user][name]}%{SPACE}:( %{DATA:[sudo][error]} ;)? TTY=%{DATA:[sudo][terminal][device]} ; PWD=%{DATA:[sudo][pwd]} ; USER=%{DATA:[sudo][user]} ; COMMAND=%{GREEDYDATA:[sudo][command]}"]
         id => "sudo"
         tag_on_failure => ["_grokparsefailure","sudo_grok_failed"]
       }
     }
     if [message] =~ /^pam_unix/ {
       grok {
-        match => ["message","pam_unix\(%{DATA:[sudo][process]}?:session\): session %{WORD:[test]} for user %{WORD:[sudo][user]}(\(uid=%{WORD:[sudo][id]}\))?( by (%{WORD:[user][name]})?\(uid=(%{WORD:[user][id]})\))?"]
+        match => ["message","pam_unix\(%{DATA:[sudo][process]}?:session\): session %{WORD:[test]} for user %{WORD:[sudo][user]}(\(uid=%{WORD:[sudo][id]}\))?( by (%{SPACE}%{WORD:[user][name]}%{SPACE})?\(uid=(%{WORD:[user][id]})\))?"]
         id => "sudo_session_status"
         tag_on_failure => ["_grokparsefaillure","sudo_session_status_grok_failed"]
       }


### PR DESCRIPTION
fixes #4

Putting `%{SPACE}` before and after each username costs some performance and might not be neccessary in every case. But it's a more or less "catch all" solution to usernames containing whitespaces.